### PR TITLE
changed versions for devkit and cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "zone.js": "~0.9.1"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~0.803.21",
-    "@angular/cli": "~8.3.21",
+    "@angular-devkit/build-angular": "~0.801.2",
+    "@angular/cli": "~8.3.24",
     "@angular/compiler-cli": "~8.2.14",
     "@angular/language-service": "~8.2.14",
     "@types/node": "~8.9.4",


### PR DESCRIPTION
Looks like there's a problem with the 8.03 version of devkit that is making that Generating ES5 bundle... freeze on AWS. 

Pull the new `package.json` file, run the command `npm install` inside `/var/www/Resume` and then run the command `ng build`